### PR TITLE
Discounts and invoices

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -28,8 +28,14 @@ class Invoice < ApplicationRecord
     invoice.invoice_items.sum('unit_price * quantity') / 100.to_f
   end
 
+  def merchant_revenue_for_invoice(merchant)
+    merchant.invoice_items
+            .sum('invoice_items.unit_price * invoice_items.quantity') / 100.to_f
+  end
+  
 
-  def discount_revenue_for_merchant(merchant_id)
+
+  def discount_revenue_for_merchant(merchant)
      y = merchants.where(id: merchant_id)
      .joins(:bulk_discounts)
      .where('invoice_items.quantity >= bulk_discounts.threshold')

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -29,12 +29,11 @@ class Invoice < ApplicationRecord
   end
 
   def merchant_revenue_for_invoice(merchant)
-    merchant.invoice_items
-            .sum('invoice_items.unit_price * invoice_items.quantity') / 100.to_f
+    merchant.invoice_items.joins(:invoice).where("invoices.id = ?", self.id).sum('invoice_items.unit_price * invoice_items.quantity') / 100.to_f
+    # merchant.invoice_items
+    #         .sum('invoice_items.unit_price * invoice_items.quantity') / 100.to_f
   end
   
-
-
   def discount_amount_for_merchant(merchant)
     discount = merchants.where(id: merchant.id)
     .joins(:bulk_discounts)
@@ -46,5 +45,12 @@ class Invoice < ApplicationRecord
     .sum
     discount / 100.to_f
   end
+
+  def merchant_revenue_after_discount(merchant)
+    amount = discount_amount_for_merchant(merchant)
+    total_revenue = merchant_revenue_for_invoice(merchant)
+    total_revenue - amount
+  end
+  
   
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -35,15 +35,16 @@ class Invoice < ApplicationRecord
   
 
 
-  def discount_revenue_for_merchant(merchant)
-     y = merchants.where(id: merchant_id)
-     .joins(:bulk_discounts)
-     .where('invoice_items.quantity >= bulk_discounts.threshold')
-     .select('invoice_items.*').group('invoice_items.item_id')
-     .maximum('invoice_items.quantity * invoice_items.unit_price * bulk_discounts.percentage / 100')
-     .pluck(1)
-     .sum
-    binding.pry
+  def discount_amount_for_merchant(merchant)
+    discount = merchants.where(id: merchant.id)
+    .joins(:bulk_discounts)
+    .where('invoice_items.quantity >= bulk_discounts.threshold')
+    .select('invoice_items.*')
+    .group('invoice_items.item_id')
+    .maximum('invoice_items.quantity * invoice_items.unit_price * bulk_discounts.percentage / 100')
+    .pluck(1)
+    .sum
+    discount / 100.to_f
   end
   
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -3,6 +3,7 @@ class Invoice < ApplicationRecord
   has_many :items, through: :invoice_items, dependent: :destroy
   belongs_to :customer
   has_many :transactions, dependent: :destroy
+  has_many :merchants, through: :items
 
   enum status: [:cancelled, 'in progress', :completed]
 
@@ -26,4 +27,17 @@ class Invoice < ApplicationRecord
     invoice = Invoice.find(invoice_id)
     invoice.invoice_items.sum('unit_price * quantity') / 100.to_f
   end
+
+
+  def discount_revenue_for_merchant(merchant_id)
+     y = merchants.where(id: merchant_id)
+     .joins(:bulk_discounts)
+     .where('invoice_items.quantity >= bulk_discounts.threshold')
+     .select('invoice_items.*').group('invoice_items.item_id')
+     .maximum('invoice_items.quantity * invoice_items.unit_price * bulk_discounts.percentage / 100')
+     .pluck(1)
+     .sum
+    binding.pry
+  end
+  
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -15,14 +15,19 @@ class InvoiceItem < ApplicationRecord
   end
 
   def has_discount?
-    # binding.pry
     if  bulk_discounts.where('? >= threshold', quantity).empty? == false
       true
-    # x = bulk_discounts.where('? >= threshold', quantity).order(percentage: :desc)
     else 
       false
    end 
   end
+
+  def discount
+    bulk_discounts.where('? >= threshold', quantity)
+    .order(percentage: :desc)
+    .first
+  end
+  
   
 
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -14,4 +14,15 @@ class InvoiceItem < ApplicationRecord
     unit_price / 100.to_f
   end
 
+  def has_discount?
+    # binding.pry
+    if  bulk_discounts.where('? >= threshold', quantity).empty? == false
+      true
+    # x = bulk_discounts.where('? >= threshold', quantity).order(percentage: :desc)
+    else 
+      false
+   end 
+  end
+  
+
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -2,7 +2,8 @@ class InvoiceItem < ApplicationRecord
   belongs_to :invoice
   belongs_to :item
   has_one :merchant, through: :item
-
+  has_many :bulk_discounts, through: :merchant
+  
   enum status: {packaged: 0, pending: 1, shipped: 2}
   validates_presence_of :quantity
   validates_presence_of :status
@@ -13,7 +14,4 @@ class InvoiceItem < ApplicationRecord
     unit_price / 100.to_f
   end
 
-  # def incomplete_invoices
-  # invoice_items.where(status: [0,1])
-  # end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,6 +1,7 @@
 class InvoiceItem < ApplicationRecord
   belongs_to :invoice
   belongs_to :item
+  has_one :merchant, through: :item
 
   enum status: {packaged: 0, pending: 1, shipped: 2}
   validates_presence_of :quantity

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -88,9 +88,9 @@ class Merchant < ApplicationRecord
   end
   
   def invoice_revenue_with_discounts(invoice_id)
-    invoice = Invoice.find(invoice_id)
-    x = invoice.invoice_items
-  end
+   
+
+  end 
   
   
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -30,33 +30,24 @@ class Merchant < ApplicationRecord
     invoices.uniq
   end
 
-
-  def current_invoice_items(invoice_id)
-    invoice_items.where(invoice_id: invoice_id)
-  end
-
-  def total_revenue_for_invoice(invoice_id)
-    invoice = Invoice.find(invoice_id)
-    invoice.invoice_items.sum('unit_price * quantity') / 100.to_f
-  end
-
-
+  
+  
   def self.status_enabled
     where(status: 0)
   end
-
+  
   def self.status_disabled
     where(status: 1)
   end
-
+  
   def enabled_items
     items.where(status: 1)
   end
-
+  
   def disabled_items
     items.where(status: 0)
   end
-
+  
   def top_five_items
     items.joins(invoice_items: [invoice: :transactions])
     .where(transactions: {result: 0})
@@ -65,9 +56,9 @@ class Merchant < ApplicationRecord
     # .order('items.*, sum(invoice_items.quantity * invoice_items.unit_price)')
     .group(:id)
     .limit(5)
-
+    
   end
-
+  
   def self.top_5_by_revenue
     joins(:invoices, [:transactions, :invoice_items])
     .where(transactions: {result: 0})
@@ -75,9 +66,9 @@ class Merchant < ApplicationRecord
     .group(:id)
     .order('total_revenue DESC')
     .limit(5)
-
+    
   end
-
+  
   def top_revenue_day
     invoices.joins(:transactions, :invoice_items)
     .where(transactions: {result: 0})
@@ -87,6 +78,19 @@ class Merchant < ApplicationRecord
     .first.created_at.to_datetime
   end
 
-  
+  def current_invoice_items(invoice_id)
+    invoice_items.where(invoice_id: invoice_id)
+  end
 
+  def total_revenue_for_invoice(invoice_id)
+    invoice = Invoice.find(invoice_id)
+    invoice.invoice_items.sum('unit_price * quantity') / 100.to_f
+  end
+  
+  def invoice_revenue_with_discounts(invoice_id)
+    invoice = Invoice.find(invoice_id)
+    x = invoice.invoice_items
+  end
+  
+  
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -29,6 +29,6 @@
 <% end %>
 <h3>Total Revenue From This Invoice:</h3>
 <section id="total_revenue">
-  Revenue: $<%= @merchant.total_revenue_for_invoice(@invoice.id)  %>
-  Revenue After Discount: $<%= @merchant.invoice_revenue_with_discounts(@invoice.id)  %>
+  Revenue: $<%="%.2f" % @invoice.merchant_revenue_for_invoice(@merchant) %><br>
+  Revenue After Discount: $<%="%.2f" % @invoice.merchant_revenue_after_discount(@merchant)  %>
 </section>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -30,5 +30,5 @@
 <h3>Total Revenue From This Invoice:</h3>
 <section id="total_revenue">
   Revenue: $<%= @merchant.total_revenue_for_invoice(@invoice.id)  %>
-  Revenue After Discount: $<%= @merchant.invoice_revenue_with_discount(@invoice.id)  %>
+  Revenue After Discount: $<%= @merchant.invoice_revenue_with_discounts(@invoice.id)  %>
 </section>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -19,7 +19,11 @@
     <%= f.hidden_field :invoice_item_id, value: "#{invoice_item.id}"  %>
     <%= f.hidden_field :invoice_id, value: "#{@invoice.id}"  %>
 
-    <%= f.submit 'Update Item Status' %>
+    <%= f.submit 'Update Item Status' %><br>
+  Link to Applicable Bulk Discount: <% if invoice_item.has_discount? == true %>
+                                   <%= link_to "Link to Applied Bulk Discount", "/merchants/#{@merchant.id}/bulk_discounts/#{invoice_item.bulk_discount.id}" %> 
+
+                                    <% end  %>
   <% end %>
   <br><br>
 

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -30,4 +30,5 @@
 <h3>Total Revenue From This Invoice:</h3>
 <section id="total_revenue">
   Revenue: $<%= @merchant.total_revenue_for_invoice(@invoice.id)  %>
+  Revenue After Discount: $<%= @merchant.invoice_revenue_with_discount(@invoice.id)  %>
 </section>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -20,10 +20,10 @@
     <%= f.hidden_field :invoice_id, value: "#{@invoice.id}"  %>
 
     <%= f.submit 'Update Item Status' %><br>
-  Link to Applicable Bulk Discount: <% if invoice_item.has_discount? == true %>
-                                   <%= link_to "Link to Applied Bulk Discount", "/merchants/#{@merchant.id}/bulk_discounts/#{invoice_item.discount.id}" %> 
-
-                                    <% end  %>
+  
+    <% if invoice_item.has_discount? == true %>
+      <%= link_to "Link to Applied Bulk Discount", "/merchants/#{@merchant.id}/bulk_discounts/#{invoice_item.discount.id}" %> 
+    <% end  %>
   <% end %>
   <br><br>
 

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -30,5 +30,5 @@
 <h3>Total Revenue From This Invoice:</h3>
 <section id="total_revenue">
   Revenue: $<%= @merchant.total_revenue_for_invoice(@invoice.id)  %>
-  Revenue After Discount: $<%= @merchant.invoice_revenue_with_discounts(@invoice.id)  %>
+  <%# Revenue After Discount: $<%= @merchant.invoice_revenue_with_discounts(@invoice.id)  %> %>
 </section>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -30,5 +30,5 @@
 <h3>Total Revenue From This Invoice:</h3>
 <section id="total_revenue">
   Revenue: $<%= @merchant.total_revenue_for_invoice(@invoice.id)  %>
-  <%# Revenue After Discount: $<%= @merchant.invoice_revenue_with_discounts(@invoice.id)  %> %>
+  Revenue After Discount: $<%= @merchant.invoice_revenue_with_discounts(@invoice.id)  %>
 </section>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -21,7 +21,7 @@
 
     <%= f.submit 'Update Item Status' %><br>
   Link to Applicable Bulk Discount: <% if invoice_item.has_discount? == true %>
-                                   <%= link_to "Link to Applied Bulk Discount", "/merchants/#{@merchant.id}/bulk_discounts/#{invoice_item.bulk_discount.id}" %> 
+                                   <%= link_to "Link to Applied Bulk Discount", "/merchants/#{@merchant.id}/bulk_discounts/#{invoice_item.discount.id}" %> 
 
                                     <% end  %>
   <% end %>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -143,6 +143,35 @@ RSpec.describe 'Merchant Invoice Show Page' do
       expect(page).to have_content("Revenue After Discount: $20.80")
     end
 
+    it 'Next to each invoice item i see a link to the bulk discount show page (if one is applied)' do
+      custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
+      merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+      item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
+      item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+      
+      disc1 = BulkDiscount.create!(name: '10 for 10%', percentage: 10, threshold: 10, merchant_id: merch1.id)
+      disc2 = BulkDiscount.create!(name: '5 for 5%', percentage: 5, threshold: 5, merchant_id: merch1.id)
+      disc3 = BulkDiscount.create!(name: '5 for 20%', percentage: 20, threshold: 5, merchant_id: merch1.id)
+
+      
+      invoice1 = Invoice.create!(status: 0, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 1, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+
+      visit "/merchants/#{merch1.id}/invoices/#{invoice1.id}"
+
+      within "#invoice_item-#{invoice_item_1.id}" do
+        expect(page).to_not have_content("Link to Applied Bulk Discount")
+      end
+
+      within "#invoice_item-#{invoice_item_2.id}" do
+        expect(page).to have_content("Link to Applied Bulk Discount")
+        click_link "Link to Applied Bulk Discount"
+      end
+      expect(current_path).to eq("/merchants/#{merch1.id}/bulk_discounts/#{disc3.id}")
+
+    end
+
 
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Merchant Invoice Show Page' do
       invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 11, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 5, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       invoice_item_3 = InvoiceItem.create(item_id: item3.id, unit_price: item3.unit_price, quantity: 2, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
-      binding.pry
+
       #this invoice and item should not be part of the calculation
       invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
       invoice_item_2 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
@@ -159,7 +159,7 @@ RSpec.describe 'Merchant Invoice Show Page' do
       invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
 
       visit "/merchants/#{merch1.id}/invoices/#{invoice1.id}"
-
+      save_and_open_page
       within "#invoice_item-#{invoice_item_1.id}" do
         expect(page).to_not have_content("Link to Applied Bulk Discount")
       end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Merchant Invoice Show Page' do
       invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 11, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 5, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       invoice_item_3 = InvoiceItem.create(item_id: item3.id, unit_price: item3.unit_price, quantity: 2, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
-
+      binding.pry
       #this invoice and item should not be part of the calculation
       invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
       invoice_item_2 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -110,6 +110,39 @@ RSpec.describe 'Merchant Invoice Show Page' do
         expect(page).to have_content("shipped")
       end
     end
+  end
+
+# bulk discounts 
+
+  describe "Bulk Discounts, As a Visitor on Merchant/Invoice Show Page" do
+
+    it 'I see a total revenue calculation with discounts included and without' do
+      custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
+      merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+      item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
+      item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+      item3 = merch1.items.create!(name: 'Alot of Cheese', description: "It's cheese", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+      item4 = merch1.items.create!(name: 'Not Cheese', description: "It is NOT cheese", unit_price: 2000, created_at: Time.now, updated_at: Time.now)
+
+      disc1 = BulkDiscount.create!(name: '10 for 10%', percentage: 10, threshold: 10, merchant_id: merch1.id)
+      disc2 = BulkDiscount.create!(name: '5 for 5%', percentage: 5, threshold: 5, merchant_id: merch1.id)
+      disc3 = BulkDiscount.create!(name: '5 for 20%', percentage: 20, threshold: 5, merchant_id: merch1.id)
+
+      invoice1 = Invoice.create!(status: 0, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 11, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 5, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_3 = InvoiceItem.create(item_id: item3.id, unit_price: item3.unit_price, quantity: 2, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+
+      #this invoice and item should not be part of the calculation
+      invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_2 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
+      
+      visit "/merchants/#{merch1.id}/invoices/#{invoice1.id}"
+      save_and_open_page
+      expect(page).to have_content("Revenue: $25.0")
+      expect(page).to have_content("Revenue After Discount: ")
+    end
+
 
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Merchant Invoice Show Page' do
 
   describe "Bulk Discounts, As a Visitor on Merchant/Invoice Show Page" do
 
-    it 'I see a total revenue calculation with discounts included and without' do
+    xit 'I see a total revenue calculation with discounts included and without' do
       custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
       merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
       item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe 'Merchant Invoice Show Page' do
       visit "/merchants/#{merch1.id}/invoices/#{invoice1.id}"
       save_and_open_page
       expect(page).to have_content("Revenue: $25.0")
-      expect(page).to have_content("Revenue After Discount: ")
+      expect(page).to have_content("Revenue After Discount: $21.90 ")
     end
 
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Merchant Invoice Show Page' do
 
   describe "Bulk Discounts, As a Visitor on Merchant/Invoice Show Page" do
 
-    xit 'I see a total revenue calculation with discounts included and without' do
+    it 'I see a total revenue calculation with discounts included and without' do
       custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
       merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
       item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
@@ -138,9 +138,9 @@ RSpec.describe 'Merchant Invoice Show Page' do
       invoice_item_2 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
       
       visit "/merchants/#{merch1.id}/invoices/#{invoice1.id}"
-      save_and_open_page
-      expect(page).to have_content("Revenue: $25.0")
-      expect(page).to have_content("Revenue After Discount: $21.90 ")
+      # save_and_open_page
+      expect(page).to have_content("Revenue: $25.00")
+      expect(page).to have_content("Revenue After Discount: $20.80")
     end
 
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe 'Merchant Invoice Show Page' do
       invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
 
       visit "/merchants/#{merch1.id}/invoices/#{invoice1.id}"
-      save_and_open_page
+      # save_and_open_page
       within "#invoice_item-#{invoice_item_1.id}" do
         expect(page).to_not have_content("Link to Applied Bulk Discount")
       end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -49,6 +49,23 @@ RSpec.describe InvoiceItem, type: :model do
       expect(invoice_item_1.has_discount?).to eq(false)
     end
 
+    it '#discount returns the highest percentage applicable discount for an invoice_item' do
+      custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
+      merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+      item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
+      item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+      
+      disc1 = BulkDiscount.create!(name: '10 for 10%', percentage: 10, threshold: 10, merchant_id: merch1.id)
+      disc2 = BulkDiscount.create!(name: '5 for 5%', percentage: 5, threshold: 5, merchant_id: merch1.id)
+      disc3 = BulkDiscount.create!(name: '5 for 20%', percentage: 20, threshold: 5, merchant_id: merch1.id)
+
+      
+      invoice1 = Invoice.create!(status: 0, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_1 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      expect(invoice_item_1.discount).to eq(disc3)
+      expect(invoice_item_1.discount.id).to eq(disc3.id)
+
+    end
 
   end 
 

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe InvoiceItem, type: :model do
       invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 1, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
 
-      expect(invoice_item_1.has_discount?).to eq(false)
       expect(invoice_item_2.has_discount?).to eq(true)
+      expect(invoice_item_1.has_discount?).to eq(false)
     end
 
 

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe InvoiceItem, type: :model do
   describe 'relationships' do
     it { should belong_to(:item) }
     it { should belong_to(:invoice) }
-    it { should have_one(:merchant).through(:item) }
+    it { should have_many(:bulk_discounts).through(:merchant) }
   end
 
   describe 'instance methods' do

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -26,8 +26,30 @@ RSpec.describe InvoiceItem, type: :model do
       expect(invoice_item_1.price_to_dollars).to eq(751.07)
 
     end
-
-
-
   end
+
+  describe 'Bulk Discounts Instance Methods' do
+
+    it '#has_discount? returns true if an invoice item has an applicable discount' do
+      custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
+      merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+      item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
+      item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+      
+      disc1 = BulkDiscount.create!(name: '10 for 10%', percentage: 10, threshold: 10, merchant_id: merch1.id)
+      disc2 = BulkDiscount.create!(name: '5 for 5%', percentage: 5, threshold: 5, merchant_id: merch1.id)
+      disc3 = BulkDiscount.create!(name: '5 for 20%', percentage: 20, threshold: 5, merchant_id: merch1.id)
+
+      
+      invoice1 = Invoice.create!(status: 0, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 1, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+
+      expect(invoice_item_1.has_discount?).to eq(false)
+      expect(invoice_item_2.has_discount?).to eq(true)
+    end
+
+
+  end 
+
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe InvoiceItem, type: :model do
       disc2 = BulkDiscount.create!(name: '5 for 5%', percentage: 5, threshold: 5, merchant_id: merch1.id)
       disc3 = BulkDiscount.create!(name: '5 for 20%', percentage: 20, threshold: 5, merchant_id: merch1.id)
 
-      
       invoice1 = Invoice.create!(status: 0, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
       invoice_item_1 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       expect(invoice_item_1.discount).to eq(disc3)

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe InvoiceItem, type: :model do
   describe 'relationships' do
     it { should belong_to(:item) }
     it { should belong_to(:invoice) }
+    it { should have_one(:merchant).through(:item) }
   end
 
   describe 'instance methods' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Invoice, type: :model do
   end
 
   describe 'invoice revenue calculation' do
-    xit 'calculates total revenue on invoice' do
+    it 'calculates total revenue on invoice' do
         merch1 = FactoryBot.create(:merchant)
         merch2 = FactoryBot.create(:merchant)
         cust1 = FactoryBot.create(:customer)
@@ -213,7 +213,7 @@ RSpec.describe Invoice, type: :model do
       invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
       invoice_item_6 = InvoiceItem.create!(item_id: item3.id, invoice_id: invoice2.id, quantity: 55, unit_price: item3.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
 
-      expect(invoice1.revenue_after_discount(merch1)).to eq(21.9)
+      expect(invoice1.merchant_revenue_after_discount(merch1)).to eq(21.6)
 
     end
     

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Invoice, type: :model do
       end
     end
   describe "bulk discounts, class and instance methods" do
-    it 'returns a merchants revenue after applicable discounts for a given invoice' do
+    it 'returns a merchants dollar amount discount after applicable discounts for a given invoice' do
       custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
       invoice1 = Invoice.create!(status: 1, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
       
@@ -159,10 +159,10 @@ RSpec.describe Invoice, type: :model do
       disc2 = BulkDiscount.create!(name: '4 for 60%', percentage: 60, threshold: 4, merchant_id: merch2.id)
       
       #this invoice and item should not be part of the calculation
-      # invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
-      # invoice_item_6 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_6 = InvoiceItem.create!(item_id: item3.id, invoice_id: invoice2.id, quantity: 55, unit_price: item3.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
 
-      expect(invoice1.discount_revenue_for_merchant(merch1.id)).to eq(21.90)
+      expect(invoice1.discount_amount_for_merchant(merch1)).to eq(4.4)
     end 
     
     it 'returns the invoice revenue for a given merchant' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Invoice, type: :model do
   end
 
   describe 'invoice revenue calculation' do
-    it 'calculates total revenue on invoice' do
+    xit 'calculates total revenue on invoice' do
         merch1 = FactoryBot.create(:merchant)
         merch2 = FactoryBot.create(:merchant)
         cust1 = FactoryBot.create(:customer)
@@ -182,7 +182,7 @@ RSpec.describe Invoice, type: :model do
       merch2 = Merchant.create!(name: 'Cheese Corp', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
       item5 = merch2.items.create!(name: "Brisket", description: "just a brisket", unit_price: 500, created_at: Time.now, updated_at: Time.now)
       invoice_item_5 = InvoiceItem.create(item_id: item5.id, unit_price: item5.unit_price, quantity: 15, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
-      expect(invoice1.merchant_revenue_for_invoice(merch1.id)).to eq(26.0)
+      expect(invoice1.merchant_revenue_for_invoice(merch1)).to eq(26.0)
     end 
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -113,27 +113,26 @@ RSpec.describe Invoice, type: :model do
 
   describe 'invoice revenue calculation' do
     it 'calculates total revenue on invoice' do
-        merch1 = FactoryBot.create(:merchant)
-        merch2 = FactoryBot.create(:merchant)
-        cust1 = FactoryBot.create(:customer)
-        item1 = FactoryBot.create(:item, merchant_id: merch1.id, unit_price: 1000)
-        item2 = FactoryBot.create(:item, merchant_id: merch1.id, unit_price: 1000)
-        item3 = FactoryBot.create(:item, merchant_id: merch1.id, unit_price: 1000)
-        item4 = FactoryBot.create(:item, merchant_id: merch2.id, unit_price: 1000)
+      merch1 = FactoryBot.create(:merchant)
+      merch2 = FactoryBot.create(:merchant)
+      cust1 = FactoryBot.create(:customer)
+      item1 = FactoryBot.create(:item, merchant_id: merch1.id, unit_price: 1000)
+      item2 = FactoryBot.create(:item, merchant_id: merch1.id, unit_price: 1000)
+      item3 = FactoryBot.create(:item, merchant_id: merch1.id, unit_price: 1000)
+      item4 = FactoryBot.create(:item, merchant_id: merch2.id, unit_price: 1000)
 
-        invoice1 = FactoryBot.create(:invoice, customer_id: cust1.id)
-        invoice_item_1 = FactoryBot.create(:invoice_item, item_id: item1.id, invoice_id: invoice1.id, unit_price: item1.unit_price, quantity: 1)
-        invoice_item_2 = FactoryBot.create(:invoice_item, item_id: item2.id, invoice_id: invoice1.id, unit_price: item2.unit_price, quantity: 1)
-        invoice_item_4 = FactoryBot.create(:invoice_item, item_id: item3.id, invoice_id: invoice1.id, unit_price: item4.unit_price, quantity: 1)
-        invoice_item_3 = FactoryBot.create(:invoice_item, item_id: item4.id, invoice_id: invoice1.id, unit_price: item3.unit_price, quantity: 1)
+      invoice1 = FactoryBot.create(:invoice, customer_id: cust1.id)
+      invoice_item_1 = FactoryBot.create(:invoice_item, item_id: item1.id, invoice_id: invoice1.id, unit_price: item1.unit_price, quantity: 1)
+      invoice_item_2 = FactoryBot.create(:invoice_item, item_id: item2.id, invoice_id: invoice1.id, unit_price: item2.unit_price, quantity: 1)
+      invoice_item_4 = FactoryBot.create(:invoice_item, item_id: item3.id, invoice_id: invoice1.id, unit_price: item4.unit_price, quantity: 1)
+      invoice_item_3 = FactoryBot.create(:invoice_item, item_id: item4.id, invoice_id: invoice1.id, unit_price: item3.unit_price, quantity: 1)
 
-        invoice2 = FactoryBot.create(:invoice, customer_id: cust1.id)
-        invoice_item_5 = FactoryBot.create(:invoice_item, item_id: item2.id, invoice_id: invoice2.id, unit_price: item2.unit_price, quantity: 10)
-# require "pry"; binding.pry
-        expect(Invoice.revenue_for_invoice(invoice2.id)).to eq(100.00)
-        expect(Invoice.revenue_for_invoice(invoice1.id)).to eq(40.00)
-      end
+      invoice2 = FactoryBot.create(:invoice, customer_id: cust1.id)
+      invoice_item_5 = FactoryBot.create(:invoice_item, item_id: item2.id, invoice_id: invoice2.id, unit_price: item2.unit_price, quantity: 10)
+      expect(Invoice.revenue_for_invoice(invoice2.id)).to eq(100.00)
+      expect(Invoice.revenue_for_invoice(invoice1.id)).to eq(40.00)
     end
+  end
 
     describe "bulk discounts, class and instance methods" do
       it 'returns the invoice revenue for a given merchant' do
@@ -145,7 +144,6 @@ RSpec.describe Invoice, type: :model do
         item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
         item3 = merch1.items.create!(name: 'Alot of Cheese', description: "It's cheese", unit_price: 200, created_at: Time.now, updated_at: Time.now)
   
-        
         invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 10, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
         invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 6, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
         invoice_item_3 = InvoiceItem.create(item_id: item3.id, unit_price: item3.unit_price, quantity: 2, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
@@ -164,7 +162,6 @@ RSpec.describe Invoice, type: :model do
       item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
       item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
       item3 = merch1.items.create!(name: 'Alot of Cheese', description: "It's cheese", unit_price: 200, created_at: Time.now, updated_at: Time.now)
-      # item4 = merch1.items.create!(name: 'Not Cheese', description: "It is NOT cheese", unit_price: 2000, created_at: Time.now, updated_at: Time.now)
 
       disc1 = BulkDiscount.create!(name: '10 for 10%', percentage: 10, threshold: 10, merchant_id: merch1.id)
       disc2 = BulkDiscount.create!(name: '5 for 5%', percentage: 5, threshold: 5, merchant_id: merch1.id)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -134,5 +134,34 @@ RSpec.describe Invoice, type: :model do
         expect(Invoice.revenue_for_invoice(invoice1.id)).to eq(40.00)
       end
     end
+  descirte "bulk discounts, class and instance methods" do
+    it 'returns a merchants revenue after applicable discounts for a given invoice' do
+      custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
+      invoice1 = Invoice.create!(status: 1, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      
+      merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+      item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
+      item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+      item3 = merch1.items.create!(name: 'Alot of Cheese', description: "It's cheese", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+      item4 = merch1.items.create!(name: 'Not Cheese', description: "It is NOT cheese", unit_price: 2000, created_at: Time.now, updated_at: Time.now)
 
+      disc1 = BulkDiscount.create!(name: '10 for 10%', percentage: 10, threshold: 10, merchant_id: merch1.id)
+      disc2 = BulkDiscount.create!(name: '5 for 5%', percentage: 5, threshold: 5, merchant_id: merch1.id)
+      disc3 = BulkDiscount.create!(name: '5 for 20%', percentage: 20, threshold: 5, merchant_id: merch1.id)
+      
+      invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 11, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 5, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_3 = InvoiceItem.create(item_id: item3.id, unit_price: item3.unit_price, quantity: 2, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      
+      merch2 = Merchant.create!(name: 'Cheese Corp', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+      item5 = merch2.items.create!(name: "Brisket", description: "just a brisket", unit_price: 7645, created_at: Time.now, updated_at: Time.now)
+      invoice_item_4 = InvoiceItem.create(item_id: item5.id, unit_price: item5.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      disc2 = BulkDiscount.create!(name: '4 for 60%', percentage: 60, threshold: 4, merchant_id: merch2.id)
+      
+      #this invoice and item should not be part of the calculation
+      invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_5 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
+
+      expect(invoice1.discount_revenue_for_merchant(merch1.id)).to eq(21.90)
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Invoice, type: :model do
         expect(Invoice.revenue_for_invoice(invoice1.id)).to eq(40.00)
       end
     end
-  descirte "bulk discounts, class and instance methods" do
+  describe "bulk discounts, class and instance methods" do
     it 'returns a merchants revenue after applicable discounts for a given invoice' do
       custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
       invoice1 = Invoice.create!(status: 1, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
@@ -143,25 +143,46 @@ RSpec.describe Invoice, type: :model do
       item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
       item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
       item3 = merch1.items.create!(name: 'Alot of Cheese', description: "It's cheese", unit_price: 200, created_at: Time.now, updated_at: Time.now)
-      item4 = merch1.items.create!(name: 'Not Cheese', description: "It is NOT cheese", unit_price: 2000, created_at: Time.now, updated_at: Time.now)
+      # item4 = merch1.items.create!(name: 'Not Cheese', description: "It is NOT cheese", unit_price: 2000, created_at: Time.now, updated_at: Time.now)
 
       disc1 = BulkDiscount.create!(name: '10 for 10%', percentage: 10, threshold: 10, merchant_id: merch1.id)
       disc2 = BulkDiscount.create!(name: '5 for 5%', percentage: 5, threshold: 5, merchant_id: merch1.id)
       disc3 = BulkDiscount.create!(name: '5 for 20%', percentage: 20, threshold: 5, merchant_id: merch1.id)
       
-      invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 11, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
-      invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 5, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 10, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 6, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       invoice_item_3 = InvoiceItem.create(item_id: item3.id, unit_price: item3.unit_price, quantity: 2, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       
       merch2 = Merchant.create!(name: 'Cheese Corp', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
-      item5 = merch2.items.create!(name: "Brisket", description: "just a brisket", unit_price: 7645, created_at: Time.now, updated_at: Time.now)
-      invoice_item_4 = InvoiceItem.create(item_id: item5.id, unit_price: item5.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      item5 = merch2.items.create!(name: "Brisket", description: "just a brisket", unit_price: 500, created_at: Time.now, updated_at: Time.now)
+      invoice_item_5 = InvoiceItem.create(item_id: item5.id, unit_price: item5.unit_price, quantity: 15, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       disc2 = BulkDiscount.create!(name: '4 for 60%', percentage: 60, threshold: 4, merchant_id: merch2.id)
       
       #this invoice and item should not be part of the calculation
-      invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
-      invoice_item_5 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
+      # invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      # invoice_item_6 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
 
       expect(invoice1.discount_revenue_for_merchant(merch1.id)).to eq(21.90)
+    end 
+    
+    it 'returns the invoice revenue for a given merchant' do
+      custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
+      invoice1 = Invoice.create!(status: 1, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      
+      merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+      item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
+      item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+      item3 = merch1.items.create!(name: 'Alot of Cheese', description: "It's cheese", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+
+      
+      invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 10, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 6, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_3 = InvoiceItem.create(item_id: item3.id, unit_price: item3.unit_price, quantity: 2, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      
+      merch2 = Merchant.create!(name: 'Cheese Corp', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+      item5 = merch2.items.create!(name: "Brisket", description: "just a brisket", unit_price: 500, created_at: Time.now, updated_at: Time.now)
+      invoice_item_5 = InvoiceItem.create(item_id: item5.id, unit_price: item5.unit_price, quantity: 15, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      expect(invoice1.merchant_revenue_for_invoice(merch1.id)).to eq(26.0)
+    end 
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe Merchant, type: :model do
     
     it 'returns a merchants revenue after applicable discounts for a given invoice' do
       custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
-      invoice1 = Invoice.create!(status: 0, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice1 = Invoice.create!(status: 1, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
       
       merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
       item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
@@ -333,8 +333,8 @@ RSpec.describe Merchant, type: :model do
       invoice_item_3 = InvoiceItem.create(item_id: item3.id, unit_price: item3.unit_price, quantity: 2, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       
       merch2 = Merchant.create!(name: 'Cheese Corp', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
-      item5 = merch1.items.create!(name: "Brisket", description: "just a brisket", unit_price: 7645, created_at: Time.now, updated_at: Time.now)
-      invoice_item_4 = InvoiceItem.create(item_id: item5.id, unit_price: item5.unit_price, quantity: 11, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      item5 = merch2.items.create!(name: "Brisket", description: "just a brisket", unit_price: 7645, created_at: Time.now, updated_at: Time.now)
+      invoice_item_4 = InvoiceItem.create(item_id: item5.id, unit_price: item5.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       disc2 = BulkDiscount.create!(name: '4 for 60%', percentage: 60, threshold: 4, merchant_id: merch2.id)
       
       #this invoice and item should not be part of the calculation
@@ -342,10 +342,6 @@ RSpec.describe Merchant, type: :model do
       invoice_item_5 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
 
       expect(merch1.invoice_revenue_with_discounts(invoice1.id)).to eq(21.90)
-
-
-
-
     end
 
 

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -312,40 +312,40 @@ RSpec.describe Merchant, type: :model do
   end
   ### bulk discounts project
 
-  describe "Bulk Discounts Project, Instance and Class Methods" do
+  # describe "Bulk Discounts Project, Instance and Class Methods" do
     
-    it 'returns a merchants revenue after applicable discounts for a given invoice' do
-      custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
-      invoice1 = Invoice.create!(status: 1, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+  #   it 'returns a merchants revenue after applicable discounts for a given invoice' do
+  #     custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
+  #     invoice1 = Invoice.create!(status: 1, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
       
-      merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
-      item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
-      item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
-      item3 = merch1.items.create!(name: 'Alot of Cheese', description: "It's cheese", unit_price: 200, created_at: Time.now, updated_at: Time.now)
-      item4 = merch1.items.create!(name: 'Not Cheese', description: "It is NOT cheese", unit_price: 2000, created_at: Time.now, updated_at: Time.now)
+  #     merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+  #     item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
+  #     item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+  #     item3 = merch1.items.create!(name: 'Alot of Cheese', description: "It's cheese", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+  #     item4 = merch1.items.create!(name: 'Not Cheese', description: "It is NOT cheese", unit_price: 2000, created_at: Time.now, updated_at: Time.now)
 
-      disc1 = BulkDiscount.create!(name: '10 for 10%', percentage: 10, threshold: 10, merchant_id: merch1.id)
-      disc2 = BulkDiscount.create!(name: '5 for 5%', percentage: 5, threshold: 5, merchant_id: merch1.id)
-      disc3 = BulkDiscount.create!(name: '5 for 20%', percentage: 20, threshold: 5, merchant_id: merch1.id)
+  #     disc1 = BulkDiscount.create!(name: '10 for 10%', percentage: 10, threshold: 10, merchant_id: merch1.id)
+  #     disc2 = BulkDiscount.create!(name: '5 for 5%', percentage: 5, threshold: 5, merchant_id: merch1.id)
+  #     disc3 = BulkDiscount.create!(name: '5 for 20%', percentage: 20, threshold: 5, merchant_id: merch1.id)
       
-      invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 11, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
-      invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 5, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
-      invoice_item_3 = InvoiceItem.create(item_id: item3.id, unit_price: item3.unit_price, quantity: 2, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+  #     invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 11, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+  #     invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 5, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+  #     invoice_item_3 = InvoiceItem.create(item_id: item3.id, unit_price: item3.unit_price, quantity: 2, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
       
-      merch2 = Merchant.create!(name: 'Cheese Corp', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
-      item5 = merch2.items.create!(name: "Brisket", description: "just a brisket", unit_price: 7645, created_at: Time.now, updated_at: Time.now)
-      invoice_item_4 = InvoiceItem.create(item_id: item5.id, unit_price: item5.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
-      disc2 = BulkDiscount.create!(name: '4 for 60%', percentage: 60, threshold: 4, merchant_id: merch2.id)
+  #     merch2 = Merchant.create!(name: 'Cheese Corp', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+  #     item5 = merch2.items.create!(name: "Brisket", description: "just a brisket", unit_price: 7645, created_at: Time.now, updated_at: Time.now)
+  #     invoice_item_4 = InvoiceItem.create(item_id: item5.id, unit_price: item5.unit_price, quantity: 16, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+  #     disc2 = BulkDiscount.create!(name: '4 for 60%', percentage: 60, threshold: 4, merchant_id: merch2.id)
       
-      #this invoice and item should not be part of the calculation
-      invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
-      invoice_item_5 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
+  #     #this invoice and item should not be part of the calculation
+  #     invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+  #     invoice_item_5 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
 
-      expect(merch1.invoice_revenue_with_discounts(invoice1.id)).to eq(21.90)
-    end
-
-
+  #     expect(merch1.invoice_revenue_with_discounts(invoice1.id)).to eq(21.90)
+  #   end
 
 
-  end
+
+
+  # end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -310,4 +310,46 @@ RSpec.describe Merchant, type: :model do
     expect(merchant_1.top_revenue_day).to eq(date_1)
     expect(merchant_2.top_revenue_day).to eq(date_3)
   end
+  ### bulk discounts project
+
+  describe "Bulk Discounts Project, Instance and Class Methods" do
+    
+    it 'returns a merchants revenue after applicable discounts for a given invoice' do
+      custy = Customer.create!(first_name: 'Elron', last_name: 'Hubbard', created_at: DateTime.now, updated_at: DateTime.now)
+      invoice1 = Invoice.create!(status: 0, customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      
+      merch1 = Merchant.create!(name: 'My Dog Skeeter', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+      item1 = merch1.items.create!(name: "Golden Rose", description: "24k gold rose", unit_price: 100, created_at: Time.now, updated_at: Time.now)
+      item2 = merch1.items.create!(name: 'Dark Sole Shoes', description: "Dress shoes", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+      item3 = merch1.items.create!(name: 'Alot of Cheese', description: "It's cheese", unit_price: 200, created_at: Time.now, updated_at: Time.now)
+      item4 = merch1.items.create!(name: 'Not Cheese', description: "It is NOT cheese", unit_price: 2000, created_at: Time.now, updated_at: Time.now)
+
+      disc1 = BulkDiscount.create!(name: '10 for 10%', percentage: 10, threshold: 10, merchant_id: merch1.id)
+      disc2 = BulkDiscount.create!(name: '5 for 5%', percentage: 5, threshold: 5, merchant_id: merch1.id)
+      disc3 = BulkDiscount.create!(name: '5 for 20%', percentage: 20, threshold: 5, merchant_id: merch1.id)
+      
+      invoice_item_1 = InvoiceItem.create(item_id: item1.id, unit_price: item1.unit_price, quantity: 11, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_2 = InvoiceItem.create(item_id: item2.id, unit_price: item2.unit_price, quantity: 5, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_3 = InvoiceItem.create(item_id: item3.id, unit_price: item3.unit_price, quantity: 2, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      
+      merch2 = Merchant.create!(name: 'Cheese Corp', created_at: DateTime.now, updated_at: DateTime.now, status: 1)
+      item5 = merch1.items.create!(name: "Brisket", description: "just a brisket", unit_price: 7645, created_at: Time.now, updated_at: Time.now)
+      invoice_item_4 = InvoiceItem.create(item_id: item5.id, unit_price: item5.unit_price, quantity: 11, invoice_id: invoice1.id, created_at: DateTime.now, updated_at: DateTime.now)
+      disc2 = BulkDiscount.create!(name: '4 for 60%', percentage: 60, threshold: 4, merchant_id: merch2.id)
+      
+      #this invoice and item should not be part of the calculation
+      invoice2 = Invoice.create!(customer_id: custy.id, created_at: DateTime.now, updated_at: DateTime.now)
+      invoice_item_5 = InvoiceItem.create!(item_id: item4.id, invoice_id: invoice2.id, quantity: 55, unit_price: item4.unit_price, created_at: DateTime.now, updated_at: DateTime.now)
+
+      expect(merch1.invoice_revenue_with_discounts(invoice1.id)).to eq(21.90)
+
+
+
+
+    end
+
+
+
+
+  end
 end


### PR DESCRIPTION
In this PR:

- added model methods to invoice to calculate discount amount and total revenue after discounts
- total rev after discounts now displayed on merchant/invoice show page
- if an invoice_item has an applicable discount on an invoice, a link to that discounts show page will be shown on a merchants invoice show page